### PR TITLE
Lowering go_highspeed_load to fix screen-off audio issues

### DIFF
--- a/Documentation/cpu-freq/governors.txt
+++ b/Documentation/cpu-freq/governors.txt
@@ -230,7 +230,7 @@ then speed may be bumped higher.  Default is the maximum speed
 allowed by the policy at governor initialization time.
 
 go_hispeed_load: The CPU load at which to ramp to hispeed_freq.
-Default is 99%.
+Default is 95%.
 
 above_hispeed_delay: When speed is at or above hispeed_freq, wait for
 this long before raising speed in response to continued high load.

--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -68,7 +68,7 @@ static struct mutex gov_lock;
 static unsigned int hispeed_freq;
 
 /* Go to hi speed when CPU load at or above this value. */
-#define DEFAULT_GO_HISPEED_LOAD 99
+#define DEFAULT_GO_HISPEED_LOAD 95
 static unsigned long go_hispeed_load = DEFAULT_GO_HISPEED_LOAD;
 
 /* Target load.  Lower values result in higher CPU speeds. */


### PR DESCRIPTION
Having go_highspeed_load set at 99 causes audio stutter when screen is off. Lowering to 95 fixes this.
